### PR TITLE
General function for fnr or dnr

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,18 @@ npm install @navikt/fnrvalidator
 ### Bruk
 ```
 const validator = require('@navikt/fnrvalidator')
-const result = validator.fnr('12345678910')
-const result = validator.dnr('52345678910')
+const fnr = validator.fnr('12345678910')
+const dnr = validator.dnr('52345678910')
+// eller
+const fnr = validator.nr('12345678910')
+const dnr = validator.nr('52345678910')
 ```
 
 ### Resultat
 ```
 {
    status: "valid"
+   type: "fnr" || "dnr"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ const validator = require('@navikt/fnrvalidator')
 const fnr = validator.fnr('12345678910')
 const dnr = validator.dnr('52345678910')
 // eller
-const fnr = validator.nr('12345678910')
-const dnr = validator.nr('52345678910')
+const fnr = validator.idnr('12345678910')
+const dnr = validator.idnr('52345678910')
 ```
 
 ### Resultat

--- a/src/validator.js
+++ b/src/validator.js
@@ -61,4 +61,4 @@ const birthdate = (digits, isDnr) => {
 
  exports.fnr = fnr
  exports.dnr = dnr
- exports.nr = idnr
+ exports.idnr = idnr

--- a/src/validator.js
+++ b/src/validator.js
@@ -3,24 +3,29 @@
 const elevenDigits = new RegExp('^\\d{11}$')
 
 const fnr = (digits) => {
-   return validate(digits, false)
+   return nr(digits)
 }
 
 const dnr = (digits) => {
-   return validate(digits, true)
+   return nr(digits)
+}
+
+const nr = (digits) => {
+   const isDnr = digits.substring(0, 1) >= 4
+   return validate(digits, isDnr)
 }
 
 const validate = (digits, isDnr) => {
    if (!elevenDigits.test(digits)) {
       return {
          status: "invalid",
-         reasons: ["fnr must consist of 11 digits"]
+         reasons: ["fnr or dnr must consist of 11 digits"]
       }
    }
 
    const errMsgs = [...checksums(digits), ...birthdate(digits, isDnr)]
 
-   return errMsgs.length == 0 ? {status: "valid"} : 
+   return errMsgs.length == 0 ? {status: "valid", type: isDnr ? 'dnr' : 'fnr'} :
       {
          status: "invalid",
          reasons: errMsgs
@@ -35,8 +40,8 @@ const checksums = (digits) => {
 
    if (k1 === 11) k1 = 0
    if (k2 === 11) k2 = 0
-   
-   return k1 < 10 && k2 < 10 && k1 == digits[9] && k2 == digits[10] ? 
+
+   return k1 < 10 && k2 < 10 && k1 == digits[9] && k2 == digits[10] ?
       [] : ["checksums don't match"]
 }
 
@@ -50,9 +55,10 @@ const birthdate = (digits, isDnr) => {
    const month = digits.substring(2, 4)
    const year = digits.substring(4, 6)
    const date = new Date(year, month - 1, day)
-   return (date && (date.getMonth() + 1) == month && date.getDate() == day) ? 
+   return (date && (date.getMonth() + 1) == month && date.getDate() == day) ?
       [] : ["invalid date"]
  }
 
  exports.fnr = fnr
  exports.dnr = dnr
+ exports.nr = nr

--- a/src/validator.js
+++ b/src/validator.js
@@ -3,14 +3,14 @@
 const elevenDigits = new RegExp('^\\d{11}$')
 
 const fnr = (digits) => {
-   return nr(digits)
+   return idnr(digits)
 }
 
 const dnr = (digits) => {
-   return nr(digits)
+   return idnr(digits)
 }
 
-const nr = (digits) => {
+const idnr = (digits) => {
    const isDnr = digits.substring(0, 1) >= 4
    return validate(digits, isDnr)
 }
@@ -61,4 +61,4 @@ const birthdate = (digits, isDnr) => {
 
  exports.fnr = fnr
  exports.dnr = dnr
- exports.nr = nr
+ exports.nr = idnr

--- a/tests/fnr.spec.js
+++ b/tests/fnr.spec.js
@@ -9,22 +9,24 @@ describe("fnr", function () {
    it("should accept a valid one", function () {
       const result = validator.fnr("13097248022")
       return expect(result).to.deep.equal({
-         status: "valid"
+         status: "valid",
+         type: "fnr"
       })
    })
 
    it("should compensate for checksum digits that are 11", function () {
       const result = validator.fnr("15021951940")
       return expect(result).to.deep.equal({
-         status: "valid"
+         status: "valid",
+         type: "fnr"
       })
    })
-   
+
    it("should reject if less than 11 digits", function () {
       const result = validator.fnr("1234567890")
       return expect(result).to.deep.equal({
          status: "invalid",
-         reasons: ["fnr must consist of 11 digits"]
+         reasons: ["fnr or dnr must consist of 11 digits"]
       })
    })
 
@@ -32,7 +34,7 @@ describe("fnr", function () {
       const result = validator.fnr("123456789101")
       return expect(result).to.deep.equal({
          status: "invalid",
-         reasons: ["fnr must consist of 11 digits"]
+         reasons: ["fnr or dnr must consist of 11 digits"]
       })
    })
 
@@ -40,7 +42,7 @@ describe("fnr", function () {
       const result = validator.fnr("1234567891A")
       return expect(result).to.deep.equal({
          status: "invalid",
-         reasons: ["fnr must consist of 11 digits"]
+         reasons: ["fnr or dnr must consist of 11 digits"]
       })
    })
 
@@ -83,7 +85,8 @@ describe("dnr", function () {
    it("should accept a valid one", function () {
       const result = validator.dnr("53097248016")
       return expect(result).to.deep.equal({
-         status: "valid"
+         status: "valid",
+         type: "dnr"
       })
    })
 })


### PR DESCRIPTION
It would've been helpful to validate a number without first having to know whether it's a D-number or an F-number.

This pull request keeps the original functionality, but also allows for checking a number with the function `idnr()`. As a side effect I'm including the type ('fnr' or 'dnr') in the result object for all functions:
```
{
   status: "valid"
   type: "fnr"
}
```