### PR TITLE
Set date year 00 default to 2000 instead of 1900. 

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -54,7 +54,10 @@ const birthdate = (digits, isDnr) => {
    const day = digits.substring(0, 2)
    const month = digits.substring(2, 4)
    const year = digits.substring(4, 6)
-   const date = new Date(year, month - 1, day)
+
+   // set year 00 default to 2000 instead of 1900
+   const date = new Date(year === '00' ? '2000' : year, month - 1, day)
+
    return (date && (date.getMonth() + 1) == month && date.getDate() == day) ?
       [] : ["invalid date"]
  }

--- a/tests/fnr.spec.js
+++ b/tests/fnr.spec.js
@@ -14,6 +14,22 @@ describe("fnr", function () {
       })
    })
 
+   it("should accept a standard leap year", function () {
+      const result = validator.fnr("29029648784")
+      return expect(result).to.deep.equal({
+         status: "valid",
+         type: "fnr"
+      })
+   })
+
+   it("should accept year 00 as valid leap year", function () {
+      const result = validator.fnr("29020075838")
+      return expect(result).to.deep.equal({
+         status: "valid",
+         type: "fnr"
+      })
+   })
+
    it("should compensate for checksum digits that are 11", function () {
       const result = validator.fnr("15021951940")
       return expect(result).to.deep.equal({


### PR DESCRIPTION
We cannot distinguish between year 1900 or 2000 in fnr anyway so we need to support it as leap year.