### PR TITLE
Eksporterer getType for å identifisere type.

### DIFF
--- a/src/validator.js
+++ b/src/validator.js
@@ -81,3 +81,4 @@ const birthdate = (digits, type) => {
  exports.dnr = dnr
  exports.hnr = hnr
  exports.idnr = idnr
+ exports.getType = getType


### PR DESCRIPTION
Vi ønsker ikke å støtte hnr. Eksporterer getType for å kunne validere i våre dialoger.