### PR TITLE
Legg til sif-code-scan i CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,3 +35,9 @@ jobs:
            run: yarn test
          - name: build
            run: yarn build
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -38,6 +38,8 @@ jobs:
 
    sif-code-scan:
       runs-on: ubuntu-latest
+      permissions:
+         contents: read
       steps:
          - uses: actions/checkout@v6
          - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -36,8 +36,9 @@ jobs:
          - name: build
            run: yarn build
 
-  sif-code-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+   sif-code-scan:
+      runs-on: ubuntu-latest
+      steps:
+         - uses: actions/checkout@v6
+         - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -31,3 +31,9 @@ jobs:
            run: yarn install --immutable
          - name: Run tests
            run: yarn test
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/.github/workflows/prs.yml
+++ b/.github/workflows/prs.yml
@@ -32,8 +32,9 @@ jobs:
          - name: Run tests
            run: yarn test
 
-  sif-code-scan:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+   sif-code-scan:
+      runs-on: ubuntu-latest
+      steps:
+         - uses: actions/checkout@v6
+         - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+


### PR DESCRIPTION
Legger til sif-code-scan som en parallell jobb i CI-workflowen. Denne sjekker koden for sensitive data som fødselsnummer.